### PR TITLE
Update +page.markdoc

### DIFF
--- a/src/routes/docs/tutorials/sveltekit-ssr-auth/step-7/+page.markdoc
+++ b/src/routes/docs/tutorials/sveltekit-ssr-auth/step-7/+page.markdoc
@@ -70,16 +70,14 @@ export async function GET(event) {
   const session = await account.createSession(userId, secret);
 
   // Redirect to the account page, and set the session cookie
-  const headers = new Headers({
-    location: "/account",
-    "set-cookie": event.cookies.serialize(SESSION_COOKIE, session.secret, {
-      sameSite: "strict",
-      expires: new Date(session.expire),
-      secure: true,
-      path: "/",
-    }),
+  event.cookies.set(SESSION_COOKIE, session.secret, {
+   httpOnly: true,
+   sameSite: "lax", // allows cookies to be includen on get requests (e.g. Redirects)
+   secure: true,
+   expires: new Date(session.expire),
+   path: "/",
   });
 
-  return new Response(null, { status: 302, headers });
+  redirect(302, "/account");
 }
 ```


### PR DESCRIPTION
Using sveltekit's native redirect method and changed the sameSite sttribute to `lax`.

Using sameSite: 'secure' is best at security, but when we redirect the page from /auth to /account or whatever it is, we don't see the cookie just we set before. After a hard refresh or sometimes navigating to other route fixed this.

By using sameSite: 'lax' attaches the cookies to the page we are going to visit.